### PR TITLE
Adiciona Testes integrados com testcontainers e rest-assured.

### DIFF
--- a/src/main/java/br/com/juliancambraia/config/WebConfig.java
+++ b/src/main/java/br/com/juliancambraia/config/WebConfig.java
@@ -1,10 +1,12 @@
 package br.com.juliancambraia.config;
 
 import br.com.juliancambraia.serialization.converter.YamlJackson2HttpMessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -18,6 +20,9 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private static final MediaType MEDIA_TYPE_APPLICATION_YML = MediaType.valueOf("application/x-yaml");
+    @Value("${cors.originPatterns:default}")
+    private String corsOriginPatterns = "";
+
 
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
@@ -33,5 +38,15 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(new YamlJackson2HttpMessageConverter());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        var allowedOrigins = corsOriginPatterns.split(",");
+        registry.addMapping("/**")
+                //.allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedMethods("*")
+                .allowedOrigins(allowedOrigins)
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/br/com/juliancambraia/controller/PersonController.java
+++ b/src/main/java/br/com/juliancambraia/controller/PersonController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,6 +47,7 @@ public class PersonController {
         return service.findAll();
     }
 
+    @CrossOrigin(origins = "http://localhost:8080")
     @GetMapping(value = "/{id}", produces = {MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML})
     @Operation(summary = "Find a Person", description = "Finds a Person", tags = {"People"},
             responses = {@ApiResponse(description = "Success", responseCode = "200",
@@ -59,6 +61,7 @@ public class PersonController {
         return service.findById(id);
     }
 
+    @CrossOrigin(origins = {"http://localhost:8080","https://www.oracle.com/"})
     @PostMapping(produces = {MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML},
             consumes = {MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML})
     @Operation(summary = "Adds a new Person", description = "Adds a new Person by passing in a JSON, XML or YML representation of",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+cors:
+  originPatterns: "http://localhost:8080,http://localhost:3000,https://www.oracle.com/"
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/db_api_rest_aws?useTimezone=true&serverTimezone=UTC&createDatabaseIfNotExist=true

--- a/src/test/java/br/com/juliancambraia/config/TestConfigs.java
+++ b/src/test/java/br/com/juliancambraia/config/TestConfigs.java
@@ -2,4 +2,11 @@ package br.com.juliancambraia.config;
 
 public class TestConfigs {
     public static final int SERVER_PORT = 8888;
+    public static final String HEADER_PARAM_AUTHORIZATION = "Authorization";
+    public static final String HEADER_PARAM_ORIGIN = "Origin";
+    public static final String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_XML = "application/xml";
+    public static final String CONTENT_TYPE_YML = "application/x-yaml";
+    public static final String ORIGIN_ERUDIO = "https://www.oracle.com/";
+    public static final String ORIGIN_SEMERU = "https://medium.com";
 }

--- a/src/test/java/br/com/juliancambraia/integrationtests/controller/json/PersonControllerJsonTest.java
+++ b/src/test/java/br/com/juliancambraia/integrationtests/controller/json/PersonControllerJsonTest.java
@@ -1,0 +1,218 @@
+package br.com.juliancambraia.integrationtests.controller.json;
+
+import br.com.juliancambraia.config.TestConfigs;
+import br.com.juliancambraia.integrationtests.swagger.testcontainers.AbstractTestIntegration;
+import br.com.juliancambraia.integrationtests.vo.PersonVO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PersonControllerJsonTest extends AbstractTestIntegration {
+    private static RequestSpecification specification;
+    private static ObjectMapper objectMapper;
+    private static PersonVO personVO;
+
+    @BeforeAll
+    public static void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        personVO = new PersonVO();
+    }
+
+    @Test
+    @Order(1)
+    void testCreate() throws JsonProcessingException {
+        mockPerson();
+        specification = new RequestSpecBuilder()
+                .addHeader(TestConfigs.HEADER_PARAM_ORIGIN, TestConfigs.ORIGIN_ERUDIO)
+                .setBasePath("/api/person/v1")
+                .setPort(TestConfigs.SERVER_PORT)
+                .addFilter(new RequestLoggingFilter(LogDetail.ALL))
+                .addFilter(new ResponseLoggingFilter(LogDetail.ALL))
+                .build();
+
+        var content = given()
+                .spec(specification)
+                .contentType(TestConfigs.CONTENT_TYPE_JSON)
+                .body(personVO)
+                .when()
+                .post()
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        PersonVO createdPerson = objectMapper.readValue(content, PersonVO.class);
+        personVO = createdPerson;
+
+        assertNotNull(createdPerson);
+        assertNotNull(createdPerson.getId());
+        assertNotNull(createdPerson.getFirstName());
+        assertNotNull(createdPerson.getLastName());
+        assertNotNull(createdPerson.getAddress());
+        assertNotNull(createdPerson.getGender());
+
+        assertTrue(createdPerson.getId() > 0);
+
+        assertEquals("Richard", createdPerson.getFirstName());
+        assertEquals("Stallman", createdPerson.getLastName());
+        assertEquals("New York City, New York US", createdPerson.getAddress());
+        assertEquals("Male", createdPerson.getGender());
+    }
+
+    @Test
+    @Order(2)
+    void testCreateWithWrongOrigin() throws JsonProcessingException {
+        mockPerson();
+        specification = new RequestSpecBuilder()
+                .addHeader(TestConfigs.HEADER_PARAM_ORIGIN, TestConfigs.ORIGIN_SEMERU)
+                .setBasePath("/api/person/v1")
+                .setPort(TestConfigs.SERVER_PORT)
+                .addFilter(new RequestLoggingFilter(LogDetail.ALL))
+                .addFilter(new ResponseLoggingFilter(LogDetail.ALL))
+                .build();
+
+        var content = given()
+                .spec(specification)
+                .contentType(TestConfigs.CONTENT_TYPE_JSON)
+                .body(personVO)
+                .when()
+                .post()
+                .then()
+                .statusCode(403)
+                .extract()
+                .body()
+                .asString();
+
+
+        assertNotNull(content);
+        assertEquals("Invalid CORS request", content);
+    }
+
+    private void mockPerson() {
+        personVO.setFirstName("Richard");
+        personVO.setLastName("Stallman");
+        personVO.setAddress("New York City, New York US");
+        personVO.setGender("Male");
+    }
+
+    @Test
+    @Order(3)
+    void testFindById() throws JsonProcessingException {
+        mockPerson();
+        specification = new RequestSpecBuilder()
+                .addHeader(TestConfigs.HEADER_PARAM_ORIGIN, TestConfigs.ORIGIN_ERUDIO)
+                .setBasePath("/api/person/v1")
+                .setPort(TestConfigs.SERVER_PORT)
+                .addFilter(new RequestLoggingFilter(LogDetail.ALL))
+                .addFilter(new ResponseLoggingFilter(LogDetail.ALL))
+                .build();
+
+        var content = given()
+                .spec(specification)
+                .contentType(TestConfigs.CONTENT_TYPE_JSON)
+                .pathParam("id", personVO.getId())
+                .when()
+                .get("{id}")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        PersonVO createdPerson = objectMapper.readValue(content, PersonVO.class);
+        personVO = createdPerson;
+
+        assertNotNull(createdPerson);
+        assertNotNull(createdPerson.getId());
+        assertNotNull(createdPerson.getFirstName());
+        assertNotNull(createdPerson.getLastName());
+        assertNotNull(createdPerson.getAddress());
+        assertNotNull(createdPerson.getGender());
+
+        assertTrue(createdPerson.getId() > 0);
+
+        assertEquals("Richard", createdPerson.getFirstName());
+        assertEquals("Stallman", createdPerson.getLastName());
+        assertEquals("New York City, New York US", createdPerson.getAddress());
+        assertEquals("Male", createdPerson.getGender());
+    }
+
+    @Test
+    @Order(4)
+    void testFindByIdWithWrongOrgin() throws JsonProcessingException {
+        mockPerson();
+        specification = new RequestSpecBuilder()
+                .addHeader(TestConfigs.HEADER_PARAM_ORIGIN, TestConfigs.ORIGIN_SEMERU)
+                .setBasePath("/api/person/v1")
+                .setPort(TestConfigs.SERVER_PORT)
+                .addFilter(new RequestLoggingFilter(LogDetail.ALL))
+                .addFilter(new ResponseLoggingFilter(LogDetail.ALL))
+                .build();
+
+        var content = given()
+                .spec(specification)
+                .contentType(TestConfigs.CONTENT_TYPE_JSON)
+                .pathParam("id", personVO.getId())
+                .when()
+                .get("{id}")
+                .then()
+                .statusCode(403)
+                .extract()
+                .body()
+                .asString();
+
+        assertNotNull(content);
+        assertEquals("Invalid CORS request", content);
+    }
+
+    @Test
+    void person_resource_returns_200_with_expected_gender_and_person() {
+
+        given()
+                .basePath("/api/person/v1/")
+                .port(TestConfigs.SERVER_PORT)
+                .when()
+                .get("{id}", 5)
+                .then()
+                .statusCode(200)
+                .body("gender", equalTo("Male"));
+
+    }
+
+    @Test
+    void person_resource_returns_200_with_expected_address_and_person() {
+
+        given()
+                .basePath("/api/person/v1/")
+                .port(TestConfigs.SERVER_PORT)
+                .when()
+                .get("{id}", 1)
+                .then()
+                .statusCode(200)
+                .body("address", equalToIgnoringCase("são Paulo"));
+
+    }
+}

--- a/src/test/java/br/com/juliancambraia/integrationtests/vo/PersonVO.java
+++ b/src/test/java/br/com/juliancambraia/integrationtests/vo/PersonVO.java
@@ -1,0 +1,87 @@
+package br.com.juliancambraia.integrationtests.vo;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public class PersonVO implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String address;
+    private String gender;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PersonVO personVO = (PersonVO) o;
+
+        return new EqualsBuilder()
+                .appendSuper(super.equals(o))
+                .append(id, personVO.id)
+                .append(firstName, personVO.firstName)
+                .append(lastName, personVO.lastName)
+                .append(address, personVO.address)
+                .append(gender, personVO.gender)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .appendSuper(super.hashCode())
+                .append(id)
+                .append(firstName)
+                .append(lastName)
+                .append(address)
+                .append(gender)
+                .toHashCode();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,7 @@
 server:
   port: 8888
-
+cors:
+  originPatterns: "http://localhost:8080,http://localhost:3000,https://www.oracle.com/"
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
- Uma maneira fácil e prática de gerar testes integrados sem precisar adicionar bancos em memória, tais como _H2_, _Derby_, além de podermos usufruir da técnica do _BDD_  para criar nossos testes de integração.

- A API **TestContainers** permite a integração direta com o seu próprio driver de banco de dados através de uma cópia implantada em Container Docker. Uma imagem **Dockerizada**
- A API **RestAssured**  permite testar serviços Rest em Java. Provendo uma maneira de criar chamadas HTTP sendo executada em conjunto com o framework JUnit, permitindo estruturar os testes.